### PR TITLE
Support multiple shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ $cms->get(array(
 ));
 ```
 
-### 2. Using an array
+#### 2. Using an array
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,45 @@ in associative array form. So, for example, a sermon's title can be accessed at
 
 If a failure occurs, `get` throws a `Monk\Cms\Exception`.
 
+### Multiple shows
+
+If you want to use `show` key to format API output, there are 2 ways
+
+#### 1. Using inline string
+
+For example:
+
+```php
+$cms->get(array(
+  'module'  => 'smallgroup',
+  'display' => 'list',
+  'order' => 'recent',
+  'emailencode' => 'no',
+  'howmany' => 1,
+  'page' => 1,
+  'show' => "___starttime format='g:ia'__ __endtime format='g:ia'__",
+));
+```
+
+### 2. Using an array
+
+For example:
+
+```php
+$cms->get(array(
+  'module'  => 'smallgroup',
+  'display' => 'list',
+  'order' => 'recent',
+  'emailencode' => 'no',
+  'howmany' => 1,
+  'page' => 1,
+  'show' => [
+    "__starttime format='g:ia'__",
+    "__endtime format='g:ia'__"
+  ]
+));
+```
+
 Development
 -----------
 

--- a/lib/Monk/Cms.php
+++ b/lib/Monk/Cms.php
@@ -191,6 +191,9 @@ class Cms
         $query['CMSCODE'] = $config['cmsCode'];
         $query['CMSTYPE'] = $config['cmsType'];
         if (isset($queryParams['show']) && is_array($queryParams['show'])) {
+            // To count the number of params correctly , we do not count
+            // if the value of the show key is an array. Therefore, we have -1.
+            // However,we care about its total items, so we add it
             $query['NR'] = count($queryParams) + count($queryParams['show']) - 1;
         } else {
             $query['NR'] = count($queryParams);

--- a/lib/Monk/Cms.php
+++ b/lib/Monk/Cms.php
@@ -153,16 +153,23 @@ class Cms
         $count = 0;
 
         foreach ($queryParams as $key => $value) {
-            $queryParam = "{$key}_:_{$value}";
+            if ($key==="show" && is_array($value)) {
+                foreach ($value as $showValue) {
+                    $queryParam = "{$key}_:_{$showValue}";
+                    $query["arg{$count}"] = $queryParam;
+                    $count++;
+                }
+            } else {
+                $queryParam = "{$key}_:_{$value}";
 
-            if ($key == 'module') {
-                $queryParam = $value;
-            } elseif ($value === true) {
-                $queryParam = $key;
+                if ($key == 'module') {
+                    $queryParam = $value;
+                } elseif ($value === true) {
+                    $queryParam = $key;
+                }
+                $query["arg{$count}"] = $queryParam;
+                $count++;
             }
-
-            $query["arg{$count}"] = $queryParam;
-            $count++;
         }
 
         return $query;
@@ -183,8 +190,11 @@ class Cms
         $query['SITEID'] = $config['siteId'];
         $query['CMSCODE'] = $config['cmsCode'];
         $query['CMSTYPE'] = $config['cmsType'];
-        $query['NR'] = count($queryParams);
-
+        if (isset($queryParams['show']) && is_array($queryParams['show'])) {
+            $query['NR'] = count($queryParams) + count($queryParams['show']) - 1;
+        } else {
+            $query['NR'] = count($queryParams);
+        }
         $query = array_merge($query, self::buildRequestQueryParams($queryParams));
 
         return http_build_query($query);
@@ -244,7 +254,7 @@ class Cms
 
     /**
      * Replace placeholder values with the expected values
-     * 
+     *
      * @param string $body
      * @return string
      */


### PR DESCRIPTION
## Ref

+ https://dev.azure.com/ministrybrands/1ES/_workitems/edit/114875/
+ https://dev.azure.com/ministrybrands/1ES/_workitems/edit/116032

```php
// This doesnt work and only formats that last time with the show even though they are different api show lines.
$content = $cms->get(array(
  'module'  => 'smallgroup',
  'display' => 'list',
  'order' => 'recent',
  'emailencode' => 'no',
  'show' => "___starttime format='g:ia'__",
  'show' => "__endtime format='g:ia'__",
));
```

Actually, the `array()` is the way to initialize PHP Associative Array (https://www.php.net/manual/en/language.types.array.php). It has the format of `key => value`. The key should be unique. That's why it formats the last `show` line because only the last line is chosen.

This PR supports multiple `shows` by wrapping it inside an array. So the syntax looks like this

```php
$content = $cms->get(array(
  'module'  => 'smallgroup',
  'display' => 'list',
  'order' => 'recent',
  'emailencode' => 'no',
  'howmany' => 1,
  'page' => 1,
  'show' => [
    "__starttime format='g:ia'__",
    "__endtime format='g:ia'__"
  ]
));
```

The inline option is working as usual `'show' => "___starttime format='g:ia'__ __endtime format='g:ia'__",`